### PR TITLE
Minimized window restore by TransitionMode.NewOrActive

### DIFF
--- a/.NET4.0/Livet(.NET4.0)/Behaviors/Messaging/TransitionInteractionMessageAction.cs
+++ b/.NET4.0/Livet(.NET4.0)/Behaviors/Messaging/TransitionInteractionMessageAction.cs
@@ -151,6 +151,11 @@ namespace Livet.Behaviors.Messaging
                             window.Owner = Window.GetWindow(AssociatedObject);
                         }
                         window.Activate();
+                        // 最小化中なら戻す
+                        if (window.WindowState == WindowState.Minimized)
+                        {
+                            window.WindowState = WindowState.Normal;
+                        }
                         transitionMessage.Response = null;
                     }
 


### PR DESCRIPTION
既に存在する最小化中のウインドウを TransitionMode.NewOrActive でアクティブにしたとき、
最小化のままでしたので、元のサイズに戻すようにしました。
