### PR TITLE
Add Multiselect to FolderBrowserDialog

### DIFF
--- a/LivetCask.Extensions/Behaviors/Messaging/IO/FolderBrowserDialogInteractionMessageAction.cs
+++ b/LivetCask.Extensions/Behaviors/Messaging/IO/FolderBrowserDialogInteractionMessageAction.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Windows;
 using Livet.Dialogs;
 using Livet.Messaging;
@@ -32,10 +33,17 @@ namespace Livet.Behaviors.Messaging.IO
                     dialog.Title = folderSelectionMessage.Title;
                     dialog.Description = folderSelectionMessage.Description;
                     dialog.SelectedPath = folderSelectionMessage.SelectedPath;
+                    dialog.Multiselect = folderSelectionMessage.Multiselect;
 
-                    folderSelectionMessage.Response = dialog.ShowDialog(hostWindow).GetValueOrDefault()
-                        ? dialog.SelectedPath
-                        : null;
+                    if (dialog.ShowDialog(hostWindow).GetValueOrDefault())
+                    {
+                        folderSelectionMessage.SelectedPaths = dialog.SelectedPaths;
+                        folderSelectionMessage.Response = folderSelectionMessage.SelectedPaths.FirstOrDefault();
+                    }
+                    else
+                    {
+                        folderSelectionMessage.Response = null;
+                    }
                 }
             }
         }

--- a/LivetCask.Extensions/Dialogs/CommonOpenFileFolderSelectionDialog.cs
+++ b/LivetCask.Extensions/Dialogs/CommonOpenFileFolderSelectionDialog.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using Livet.Annotations;
 using Microsoft.WindowsAPICodePack.Dialogs;
@@ -19,7 +21,7 @@ namespace Livet.Dialogs
         /// </summary>
         public CommonOpenFileFolderSelectionDialog()
         {
-            _commonOpenFileDialog = new CommonOpenFileDialog {IsFolderPicker = true, Multiselect = false};
+            _commonOpenFileDialog = new CommonOpenFileDialog { IsFolderPicker = true, Multiselect = false };
             _defaultTitle = _commonOpenFileDialog.Title;
         }
 
@@ -45,6 +47,16 @@ namespace Livet.Dialogs
         {
             get { return string.Empty; }
             set { }
+        }
+
+        /// <summary>
+        ///  Gets or sets whether the multi selection is enabled on the folder browser dialog.
+        /// </summary>
+        public override bool Multiselect
+        {
+            get { return _commonOpenFileDialog.Multiselect; }
+
+            set { _commonOpenFileDialog.Multiselect = value; }
         }
 
         /// <summary>
@@ -74,6 +86,14 @@ namespace Livet.Dialogs
                                                              ?? "::{20D04FE0-3AEA-1069-A2D8-08002B30309D}";
                 }
             }
+        }
+
+        /// <summary>
+        ///     Gets or sets the selected paths.
+        /// </summary>
+        public override string[] SelectedPaths
+        {
+            get { return _commonOpenFileDialog.FileNames.ToArray(); }
         }
 
         /// <summary>

--- a/LivetCask.Extensions/Dialogs/FolderBrowserFolderSelectionDialog.cs
+++ b/LivetCask.Extensions/Dialogs/FolderBrowserFolderSelectionDialog.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Windows;
@@ -69,6 +70,26 @@ namespace Livet.Dialogs
         {
             get { return string.Empty; }
             set { }
+        }
+
+
+        /// <summary>
+        ///     This property is not supported.
+        /// </summary>
+        /// <value>Always false.</value>
+        public override bool Multiselect
+        {
+            get { return false; }
+            set { }
+        }
+
+        /// <summary>
+        ///     Gets or sets the selected paths.
+        /// </summary>
+        /// <value>Always return SelectedPath.</value>
+        public override string[] SelectedPaths
+        {
+            get { return new[] { SelectedPath }; }
         }
 
         /// <summary>

--- a/LivetCask.Extensions/Dialogs/FolderSelectionDialog.cs
+++ b/LivetCask.Extensions/Dialogs/FolderSelectionDialog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Windows;
 
 namespace Livet.Dialogs
@@ -34,6 +35,17 @@ namespace Livet.Dialogs
         ///     The <c>null</c> or empty indicates using default title.
         /// </value>
         public abstract string Title { get; set; }
+
+
+        /// <summary>
+        ///  Gets or sets whether the multi selection is enabled on the folder browser dialog.
+        /// </summary>
+        public abstract bool Multiselect { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the selected paths.
+        /// </summary>
+        public abstract string[] SelectedPaths { get; }
 
         /// <summary>
         ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.

--- a/LivetCask.Extensions/Messaging/IO/FolderSelectionMessage.cs
+++ b/LivetCask.Extensions/Messaging/IO/FolderSelectionMessage.cs
@@ -19,7 +19,8 @@ namespace Livet.Messaging.IO
         /// <value>
         ///     <see cref="DependencyProperty" />.
         /// </value>
-        [NotNull] public static readonly DependencyProperty DescriptionProperty =
+        [NotNull]
+        public static readonly DependencyProperty DescriptionProperty =
             DependencyProperty.Register("Description", typeof(string), typeof(FolderSelectionMessage),
                 new UIPropertyMetadata(null));
 
@@ -29,7 +30,8 @@ namespace Livet.Messaging.IO
         /// <value>
         ///     <see cref="DependencyProperty" />.
         /// </value>
-        [NotNull] public static readonly DependencyProperty TitleProperty =
+        [NotNull]
+        public static readonly DependencyProperty TitleProperty =
             DependencyProperty.Register("Title", typeof(string), typeof(FolderSelectionMessage),
                 new UIPropertyMetadata(string.Empty));
 
@@ -39,9 +41,21 @@ namespace Livet.Messaging.IO
         /// <value>
         ///     <see cref="DependencyProperty" />.
         /// </value>
-        [NotNull] public static readonly DependencyProperty SelectedPathProperty =
+        [NotNull]
+        public static readonly DependencyProperty SelectedPathProperty =
             DependencyProperty.Register("SelectedPath", typeof(string), typeof(FolderSelectionMessage),
                 new UIPropertyMetadata(string.Empty));
+
+        /// <summary>
+        ///     Defines <see cref="SelectedPaths" /> dependency property.
+        /// </summary>
+        /// <value>
+        ///     <see cref="DependencyProperty" />.
+        /// </value>
+        [NotNull]
+        public static readonly DependencyProperty SelectedPathsProperty =
+            DependencyProperty.Register("SelectedPaths", typeof(string[]), typeof(FolderSelectionMessage),
+                new UIPropertyMetadata(new[] { string.Empty }));
 
         /// <summary>
         ///     Defines <see cref="SelectedPath" /> dependency property.
@@ -49,9 +63,22 @@ namespace Livet.Messaging.IO
         /// <value>
         ///     <see cref="DependencyProperty" />.
         /// </value>
-        [NotNull] public static readonly DependencyProperty DialogPreferenceProperty =
+        [NotNull]
+        public static readonly DependencyProperty DialogPreferenceProperty =
             DependencyProperty.Register("DialogPreference", typeof(FolderSelectionDialogPreference),
                 typeof(FileSelectionMessage), new UIPropertyMetadata(FolderSelectionDialogPreference.None));
+        /// <summary>
+        ///     Defines <see cref="Multiselect" /> dependency property.
+        /// </summary>
+        /// <value>
+        ///     <see cref="DependencyProperty" />.
+        /// </value>
+        [NotNull]
+        public static readonly DependencyProperty MultiselectProperty =
+            DependencyProperty.Register("Multiselect", typeof(bool),
+                typeof(FileSelectionMessage), new UIPropertyMetadata(false));
+
+
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="FolderSelectionMessage" /> class
@@ -93,6 +120,15 @@ namespace Livet.Messaging.IO
         }
 
         /// <summary>
+        ///     Gets or sets whether the multi selection is enabled on the folder browser dialog.
+        /// </summary>
+        public bool Multiselect
+        {
+            get { return (bool)GetValue(MultiselectProperty); }
+            set { SetValue(MultiselectProperty, value); }
+        }
+
+        /// <summary>
         ///     Gets or sets the selected path on the folder selection dialog.
         /// </summary>
         /// <value>
@@ -103,6 +139,18 @@ namespace Livet.Messaging.IO
         {
             get { return GetValue(SelectedPathProperty) as string; }
             set { SetValue(SelectedPathProperty, value); }
+        }
+
+        /// <summary>
+        ///     Gets or sets the selected paths on the folder selection dialog.
+        /// </summary>
+        /// <value>
+        ///     The selected paths on the folder selection dialog.
+        /// </value>
+        public string[] SelectedPaths
+        {
+            get { return GetValue(SelectedPathsProperty) as string[]; }
+            set { SetValue(SelectedPathsProperty, value); }
         }
 
         /// <summary>
@@ -117,7 +165,7 @@ namespace Livet.Messaging.IO
             {
                 var value = GetValue(DialogPreferenceProperty);
                 return value?.GetType() == typeof(FolderSelectionDialogPreference)
-                    ? (FolderSelectionDialogPreference) value
+                    ? (FolderSelectionDialogPreference)value
                     : default;
             }
             set { SetValue(DialogPreferenceProperty, value); }

--- a/Samples/ViewLayerSupport/ViewModels/MessagingWindowViewModel.cs
+++ b/Samples/ViewLayerSupport/ViewModels/MessagingWindowViewModel.cs
@@ -76,11 +76,25 @@ namespace ViewLayerSupport.ViewModels
             OutputMessage = $"{DateTime.Now}: ConfirmFromView: {message.Response ?? false}";
         }
 
+        public void FileSelected([NotNull] OpeningFileSelectionMessage message)
+        {
+            if (message == null) throw new ArgumentNullException(nameof(message));
+
+
+            string selectedPaths = message.Response == null
+                ? "未選択"
+                : String.Join(";", message.Response);
+            OutputMessage = $"{DateTime.Now}: FileSelected: {selectedPaths}";
+        }
         public void FolderSelected([NotNull] FolderSelectionMessage message)
         {
             if (message == null) throw new ArgumentNullException(nameof(message));
 
-            OutputMessage = $"{DateTime.Now}: FolderSelected: {message.Response ?? "未選択"}";
+            string selectedPaths = message.Response == null
+                ? "未選択"
+                : String.Join(";", message.SelectedPaths);
+
+            OutputMessage = $"{DateTime.Now}: FolderSelected: {selectedPaths}";
         }
 
         public void Initialize() { }

--- a/Samples/ViewLayerSupport/Views/MessagingWindow.xaml
+++ b/Samples/ViewLayerSupport/Views/MessagingWindow.xaml
@@ -1,75 +1,109 @@
 ﻿<Window
-    x:Class="ViewLayerSupport.Views.MessagingWindow"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
-    xmlns:l="http://schemas.livet-mvvm.net/2011/wpf"
-    xmlns:v="clr-namespace:ViewLayerSupport.Views"
-    xmlns:vm="clr-namespace:ViewLayerSupport.ViewModels"
-    Title="MessagingWindow"
-    Width="525"
-    Height="350">
+   x:Class="ViewLayerSupport.Views.MessagingWindow"
+   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+   xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+   xmlns:l="http://schemas.livet-mvvm.net/2011/wpf"
+   xmlns:v="clr-namespace:ViewLayerSupport.Views"
+   xmlns:vm="clr-namespace:ViewLayerSupport.ViewModels"
+   Title="MessagingWindow"
+   Width="525"
+   Height="350">
 
-    <Window.DataContext>
-        <vm:MessagingWindowViewModel />
-    </Window.DataContext>
+   <Window.DataContext>
+      <vm:MessagingWindowViewModel />
+   </Window.DataContext>
 
-    <i:Interaction.Triggers>
+   <i:Interaction.Triggers>
 
-        <!--  Viewに特別な要件が存在しない限りは、トリガーやアクションの自作にこだわらず積極的にコードビハインドを使いましょう  -->
-        <!--  Viewのコードビハインドは、基本的にView内で完結するロジックとViewModelからのイベントの受信(専用リスナを使用する)に限るとトラブルが少なくなります  -->
-        <!--  Livet1.1からはコードビハインドでViewModelのイベントを受信するためのWeakEventListenerサポートが追加されています  -->
+      <!--  Viewに特別な要件が存在しない限りは、トリガーやアクションの自作にこだわらず積極的にコードビハインドを使いましょう  -->
+      <!--  Viewのコードビハインドは、基本的にView内で完結するロジックとViewModelからのイベントの受信(専用リスナを使用する)に限るとトラブルが少なくなります  -->
+      <!--  Livet1.1からはコードビハインドでViewModelのイベントを受信するためのWeakEventListenerサポートが追加されています  -->
 
-        <!--  WindowのContentRenderedイベントのタイミングでViewModelのInitializeメソッドが呼ばれます  -->
-        <i:EventTrigger EventName="ContentRendered">
-            <l:LivetCallMethodAction MethodName="Initialize" MethodTarget="{Binding}" />
-        </i:EventTrigger>
+      <!--  WindowのContentRenderedイベントのタイミングでViewModelのInitializeメソッドが呼ばれます  -->
+      <i:EventTrigger EventName="ContentRendered">
+         <l:LivetCallMethodAction MethodName="Initialize" MethodTarget="{Binding}" />
+      </i:EventTrigger>
 
-        <!--  Windowが閉じたタイミングでViewModelのDisposeメソッドが呼ばれます  -->
-        <i:EventTrigger EventName="Closed">
-            <l:DataContextDisposeAction />
-        </i:EventTrigger>
+      <!--  Windowが閉じたタイミングでViewModelのDisposeメソッドが呼ばれます  -->
+      <i:EventTrigger EventName="Closed">
+         <l:DataContextDisposeAction />
+      </i:EventTrigger>
 
-        <!--  WindowのCloseキャンセル処理に対応する場合は、WindowCloseCancelBehaviorの使用を検討してください  -->
-        <l:InteractionMessageTrigger MessageKey="MessageKey_Confirm" Messenger="{Binding Messenger}">
-            <l:ConfirmationDialogInteractionMessageAction />
-        </l:InteractionMessageTrigger>
-    </i:Interaction.Triggers>
+      <!--  WindowのCloseキャンセル処理に対応する場合は、WindowCloseCancelBehaviorの使用を検討してください  -->
+      <l:InteractionMessageTrigger MessageKey="MessageKey_Confirm" Messenger="{Binding Messenger}">
+         <l:ConfirmationDialogInteractionMessageAction />
+      </l:InteractionMessageTrigger>
+   </i:Interaction.Triggers>
 
-    <StackPanel>
-        <Viewbox>
-            <TextBlock Text="{Binding OutputMessage}" />
-        </Viewbox>
-        <Button Content="ConfirmFromViewModel">
-            <i:Interaction.Triggers>
-                <i:EventTrigger EventName="Click">
-                    <l:LivetCallMethodAction MethodName="ConfirmFromViewModel" MethodTarget="{Binding}" />
-                </i:EventTrigger>
-            </i:Interaction.Triggers>
-        </Button>
-        <Button Content="ConfirmFromView">
-            <i:Interaction.Triggers>
-                <i:EventTrigger EventName="Click">
-                    <l:ConfirmationDialogInteractionMessageAction>
-                        <l:DirectInteractionMessage CallbackMethodName="ConfirmFromView"
-                                                    CallbackMethodTarget="{Binding}">
-                            <l:ConfirmationMessage Caption="テスト" Text="これはテスト用メッセージです。" />
-                        </l:DirectInteractionMessage>
-                    </l:ConfirmationDialogInteractionMessageAction>
-                </i:EventTrigger>
-            </i:Interaction.Triggers>
-        </Button>
-        <Button Content="Folder">
-            <i:Interaction.Triggers>
-                <i:EventTrigger EventName="Click">
-                    <l:FolderBrowserDialogInteractionMessageAction>
-                        <l:DirectInteractionMessage CallbackMethodName="FolderSelected"
-                                                    CallbackMethodTarget="{Binding}">
-                            <l:FolderSelectionMessage Description="フォルダーの選択" DialogPreference="None" />
-                        </l:DirectInteractionMessage>
-                    </l:FolderBrowserDialogInteractionMessageAction>
-                </i:EventTrigger>
-            </i:Interaction.Triggers>
-        </Button>
-    </StackPanel>
+   <StackPanel>
+      <Viewbox>
+         <TextBlock Text="{Binding OutputMessage}" />
+      </Viewbox>
+      <Button Content="ConfirmFromViewModel">
+         <i:Interaction.Triggers>
+            <i:EventTrigger EventName="Click">
+               <l:LivetCallMethodAction MethodName="ConfirmFromViewModel" MethodTarget="{Binding}" />
+            </i:EventTrigger>
+         </i:Interaction.Triggers>
+      </Button>
+      <Button Content="ConfirmFromView">
+         <i:Interaction.Triggers>
+            <i:EventTrigger EventName="Click">
+               <l:ConfirmationDialogInteractionMessageAction>
+                  <l:DirectInteractionMessage CallbackMethodName="ConfirmFromView" CallbackMethodTarget="{Binding}">
+                     <l:ConfirmationMessage Caption="テスト" Text="これはテスト用メッセージです。" />
+                  </l:DirectInteractionMessage>
+               </l:ConfirmationDialogInteractionMessageAction>
+            </i:EventTrigger>
+         </i:Interaction.Triggers>
+      </Button>
+      <Button Content="Single FileDialog">
+         <i:Interaction.Triggers>
+            <i:EventTrigger EventName="Click">
+               <l:OpenFileDialogInteractionMessageAction>
+                  <l:DirectInteractionMessage CallbackMethodName="FileSelected" CallbackMethodTarget="{Binding}">
+                     <l:OpeningFileSelectionMessage Title="ファイルの選択" />
+                  </l:DirectInteractionMessage>
+               </l:OpenFileDialogInteractionMessageAction>
+            </i:EventTrigger>
+         </i:Interaction.Triggers>
+      </Button>
+      <Button Content="Multi FileDialog">
+         <i:Interaction.Triggers>
+            <i:EventTrigger EventName="Click">
+               <l:OpenFileDialogInteractionMessageAction>
+                  <l:DirectInteractionMessage CallbackMethodName="FileSelected" CallbackMethodTarget="{Binding}">
+                     <l:OpeningFileSelectionMessage Title="ファイルの選択" MultiSelect="True" />
+                  </l:DirectInteractionMessage>
+               </l:OpenFileDialogInteractionMessageAction>
+            </i:EventTrigger>
+         </i:Interaction.Triggers>
+      </Button>
+      <Button Content="Single FolderDialog">
+         <i:Interaction.Triggers>
+            <i:EventTrigger EventName="Click">
+               <l:FolderBrowserDialogInteractionMessageAction>
+                  <l:DirectInteractionMessage CallbackMethodName="FolderSelected" CallbackMethodTarget="{Binding}">
+                     <l:FolderSelectionMessage Description="フォルダーの選択" DialogPreference="None" />
+                  </l:DirectInteractionMessage>
+               </l:FolderBrowserDialogInteractionMessageAction>
+            </i:EventTrigger>
+         </i:Interaction.Triggers>
+      </Button>
+      <Button Content="Multi FolderDialog">
+         <i:Interaction.Triggers>
+            <i:EventTrigger EventName="Click">
+               <l:FolderBrowserDialogInteractionMessageAction>
+                  <l:DirectInteractionMessage CallbackMethodName="FolderSelected" CallbackMethodTarget="{Binding}">
+                     <l:FolderSelectionMessage
+                        Description="フォルダーの選択"
+                        DialogPreference="None"
+                        Multiselect="True" />
+                  </l:DirectInteractionMessage>
+               </l:FolderBrowserDialogInteractionMessageAction>
+            </i:EventTrigger>
+         </i:Interaction.Triggers>
+      </Button>
+   </StackPanel>
 </Window>


### PR DESCRIPTION
#59 
FolderSelectionMessageでの複数フォルダ選択機能の追加です。


注意点として、FileSelectionの場合と複数パスの取得方法が異なります。
デモのコードを見てもらうとわかりますが、FileSelectionの場合は`message.Response`をFolderSelectionの場合は`message.SelectedPaths`を使用します。
これの原因は`FileSelectionMessage`が`ResponsiveInteractionMessage<string[]>`を継承しているのに対し、`FolderSelectionMessage`が`ResponsiveInteractionMessage<string>`を継承しているためです。

ここは私も迷ったのですが、継承ジェネリック型を変更したほうが、コードとしてはスマートになりますが、破壊的変更になります。
もし継承ジェネリック型を変更したほうが良ければ修正します。

よろしくおねがいします。
